### PR TITLE
Add honeypot field to block spam submissions

### DIFF
--- a/PeaceKeychains.Blazor/Components/Pages/Submit.razor
+++ b/PeaceKeychains.Blazor/Components/Pages/Submit.razor
@@ -87,6 +87,12 @@
                     </div>
                 </div>
 
+                <!-- Honeypot field - hidden from users, bots will fill it -->
+                <div class="hidden" aria-hidden="true" style="position:absolute;left:-9999px;">
+                    <label for="website">Website</label>
+                    <input type="text" id="website" name="Model.Website" value="@Model?.Website" tabindex="-1" autocomplete="off" />
+                </div>
+
                 <!-- Submit Button -->
                 <button type="submit"
                         class="w-full py-4 px-6 bg-gradient-to-r from-peace-500 to-peace-600 text-white font-semibold rounded-xl shadow-lg hover:from-peace-600 hover:to-peace-700 transform hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none">
@@ -178,7 +184,7 @@
             }
         }
 
-        post.Approved = true;
+        post.Approved = string.IsNullOrEmpty(Model.Website);
         DbContext.Posts.Add(post);
         await DbContext.SaveChangesAsync();
 
@@ -191,5 +197,6 @@
         public string? User { get; set; }
         public string? Text { get; set; }
         public IFormFile? Image { get; set; }
+        public string? Website { get; set; } // Honeypot field
     }
 }

--- a/PeaceKeychains.Blazor/Components/Pages/Submit.razor
+++ b/PeaceKeychains.Blazor/Components/Pages/Submit.razor
@@ -184,7 +184,7 @@
             }
         }
 
-        post.Approved = string.IsNullOrEmpty(Model.Website);
+        post.Approved = string.IsNullOrWhiteSpace(Model.Website);
         DbContext.Posts.Add(post);
         await DbContext.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary
Adds a honeypot spam filter to prevent bot submissions from appearing on the site.

## How it works
- A hidden "Website" field is added to the submit form
- The field is positioned off-screen and has `tabindex=-1` so real users won't see or interact with it
- Bots that auto-fill all form fields will populate this honeypot
- Posts with the honeypot filled are saved with `Approved=false` (won't display)
- Legitimate posts (honeypot empty) remain auto-approved and display immediately

## Changes
- Added hidden honeypot input field to Submit.razor
- Added `Website` property to SubmitModel
- Updated approval logic: `Approved = string.IsNullOrEmpty(Model.Website)`