### PR TITLE
Add PeaceKeychains.Admin console app for post moderation

### DIFF
--- a/PeaceKeychains.Admin/PeaceKeychains.Admin.csproj
+++ b/PeaceKeychains.Admin/PeaceKeychains.Admin.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>false</SelfContained>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PeaceKeychains.Admin/PeaceKeychains.Admin.csproj
+++ b/PeaceKeychains.Admin/PeaceKeychains.Admin.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PeaceKeychains.Shared\PeaceKeychains.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+  </ItemGroup>
+
+</Project>

--- a/PeaceKeychains.Admin/Program.cs
+++ b/PeaceKeychains.Admin/Program.cs
@@ -1,0 +1,207 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using PeaceKeychains.Shared.Data;
+using PeaceKeychains.Shared.Extensions;
+
+if (args.Length == 0)
+{
+    PrintUsage();
+    return 1;
+}
+
+var command = args[0].ToLowerInvariant();
+if (command is not ("check" or "moderate"))
+{
+    Console.Error.WriteLine($"Unknown command: '{args[0]}'");
+    PrintUsage();
+    return 1;
+}
+
+var vaultUri = Environment.GetEnvironmentVariable("VaultUri");
+if (string.IsNullOrWhiteSpace(vaultUri))
+{
+    Console.Error.WriteLine("Error: Must set 'VaultUri' environment variable.");
+    return 1;
+}
+
+var configuration = new ConfigurationBuilder()
+    .AddAzureKeyVault(new Uri(vaultUri), new DefaultAzureCredential())
+    .Build();
+
+var cosmosConnectionString = configuration["ConnectionStrings:AzureCosmosDBConnectionString"]
+    ?? throw new InvalidOperationException("KeyVault must contain 'ConnectionStrings:AzureCosmosDBConnectionString'");
+
+var storageConnectionString = configuration["AzureStorageConnectionString"]
+    ?? throw new InvalidOperationException("KeyVault must contain 'AzureStorageConnectionString'");
+
+var services = new ServiceCollection();
+services.AddCosmos<PeaceKeychainsContext>(cosmosConnectionString, "PostsDB");
+services.AddAzureClients(clientBuilder =>
+{
+    clientBuilder.AddBlobServiceClient(storageConnectionString, preferMsi: false);
+});
+
+using var serviceProvider = services.BuildServiceProvider();
+using var scope = serviceProvider.CreateScope();
+var dbContext = scope.ServiceProvider.GetRequiredService<PeaceKeychainsContext>();
+var blobServiceClient = scope.ServiceProvider.GetRequiredService<BlobServiceClient>();
+
+return command switch
+{
+    "check" => await CheckAsync(dbContext),
+    "moderate" => await ModerateAsync(dbContext, blobServiceClient),
+    _ => 1
+};
+
+static async Task<int> CheckAsync(PeaceKeychainsContext dbContext)
+{
+    var count = await dbContext.Posts
+        .Where(p => !p.Approved)
+        .CountAsync();
+
+    if (count == 0)
+    {
+        Console.WriteLine("No unapproved posts.");
+    }
+    else
+    {
+        Console.WriteLine($"{count} unapproved post(s) found.");
+    }
+
+    return Math.Min(count, 125);
+}
+
+static async Task<int> ModerateAsync(PeaceKeychainsContext dbContext, BlobServiceClient blobServiceClient)
+{
+    var posts = await dbContext.Posts
+        .Where(p => !p.Approved)
+        .OrderBy(p => p.Time)
+        .ToListAsync();
+
+    if (posts.Count == 0)
+    {
+        Console.WriteLine("No unapproved posts to moderate.");
+        return 0;
+    }
+
+    Console.WriteLine($"Found {posts.Count} unapproved post(s).\n");
+
+    var approved = 0;
+    var deleted = 0;
+    var skipped = 0;
+
+    for (var i = 0; i < posts.Count; i++)
+    {
+        var post = posts[i];
+        Console.WriteLine($"--- Post {i + 1} of {posts.Count} ---");
+        Console.WriteLine($"  Title:    {post.Title}");
+        Console.WriteLine($"  User:     {post.UserName}");
+        Console.WriteLine($"  Time:     {post.Time:g}");
+        Console.WriteLine($"  Text:     {post.Text ?? "(none)"}");
+        Console.WriteLine($"  Image:    {post.OriginalImageUrl ?? "(none)"}");
+        Console.WriteLine();
+
+        var action = PromptAction();
+        switch (action)
+        {
+            case 'a':
+                post.Approved = true;
+                dbContext.Posts.Update(post);
+                await dbContext.SaveChangesAsync();
+                Console.WriteLine("  -> Post approved.\n");
+                approved++;
+                break;
+
+            case 'd':
+                if (!string.IsNullOrEmpty(post.OriginalImageUrl))
+                {
+                    await DeleteBlobAsync(blobServiceClient, post.OriginalImageUrl);
+                }
+
+                dbContext.Posts.Remove(post);
+                await dbContext.SaveChangesAsync();
+                Console.WriteLine("  -> Post deleted.\n");
+                deleted++;
+                break;
+
+            case 's':
+                Console.WriteLine("  -> Skipped.\n");
+                skipped++;
+                break;
+        }
+    }
+
+    Console.WriteLine("--- Summary ---");
+    Console.WriteLine($"  Approved: {approved}");
+    Console.WriteLine($"  Deleted:  {deleted}");
+    Console.WriteLine($"  Skipped:  {skipped}");
+
+    return 0;
+}
+
+static char PromptAction()
+{
+    while (true)
+    {
+        Console.Write("[A]pprove / [D]elete / [S]kip? ");
+        var key = Console.ReadKey(intercept: false);
+        Console.WriteLine();
+
+        var c = char.ToLowerInvariant(key.KeyChar);
+        if (c is 'a' or 'd' or 's')
+        {
+            return c;
+        }
+
+        Console.WriteLine("  Invalid choice. Please press A, D, or S.");
+    }
+}
+
+static async Task DeleteBlobAsync(BlobServiceClient blobServiceClient, string imageUrl)
+{
+    try
+    {
+        var uri = new Uri(imageUrl);
+
+        // Path is "/{container}/{blobName}" — strip leading slash and split
+        var pathSegments = uri.AbsolutePath.TrimStart('/').Split('/', 2);
+        if (pathSegments.Length != 2)
+        {
+            Console.WriteLine($"  Warning: Could not parse blob path from URL: {imageUrl}");
+            return;
+        }
+
+        var containerName = pathSegments[0];
+        var blobName = pathSegments[1];
+
+        var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = containerClient.GetBlobClient(blobName);
+
+        var deleted = await blobClient.DeleteIfExistsAsync();
+        if (deleted)
+        {
+            Console.WriteLine($"  -> Blob deleted: {blobName}");
+        }
+        else
+        {
+            Console.WriteLine($"  -> Blob not found: {blobName}");
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"  Warning: Failed to delete blob: {ex.Message}");
+    }
+}
+
+static void PrintUsage()
+{
+    Console.WriteLine("Usage: PeaceKeychains.Admin <command>");
+    Console.WriteLine();
+    Console.WriteLine("Commands:");
+    Console.WriteLine("  check       Check for unapproved posts (exit code = count, max 125)");
+    Console.WriteLine("  moderate    Interactively review unapproved posts");
+}

--- a/PeaceKeychains.sln
+++ b/PeaceKeychains.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeaceKeychains.Shared", "Pe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeaceKeychains.Blazor", "PeaceKeychains.Blazor\PeaceKeychains.Blazor.csproj", "{97C2089A-6DF3-4078-ADE2-56FF378639B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeaceKeychains.Admin", "PeaceKeychains.Admin\PeaceKeychains.Admin.csproj", "{924D0599-983E-4143-84A4-D7DB0816CC13}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{97C2089A-6DF3-4078-ADE2-56FF378639B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97C2089A-6DF3-4078-ADE2-56FF378639B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97C2089A-6DF3-4078-ADE2-56FF378639B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{924D0599-983E-4143-84A4-D7DB0816CC13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{924D0599-983E-4143-84A4-D7DB0816CC13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{924D0599-983E-4143-84A4-D7DB0816CC13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{924D0599-983E-4143-84A4-D7DB0816CC13}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
New .NET 8 console app with `PublishSingleFile` support providing two admin commands:

## Commands

- **`check`** — Counts unapproved posts, prints the count, and returns it as the process exit code (capped at 125). Useful for scripting/monitoring.
- **`moderate`** — Interactively reviews each unapproved post, displaying title, user, text, and image URL, then prompting to **[A]pprove**, **[D]elete** (removes post from Cosmos DB and blob from Azure Storage), or **[S]kip**.

## Usage

Requires the `VaultUri` environment variable (same as the web apps).

```bash
# Check for unapproved posts
dotnet run --project PeaceKeychains.Admin -- check

# Interactively moderate
dotnet run --project PeaceKeychains.Admin -- moderate

# Publish as single file
dotnet publish PeaceKeychains.Admin -c Release
```