### PR TITLE
Publish projects separately in deploy workflow

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -58,14 +58,32 @@ jobs:
       - name: Build with dotnet
         run: dotnet build --configuration Release
 
-      - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+      - name: Publish Blazor app
+        run: dotnet publish PeaceKeychains.Blazor -c Release -o ${{env.DOTNET_ROOT}}/blazor
 
-      - name: Upload artifact for deployment job
+      - name: Publish Web app
+        run: dotnet publish PeaceKeychains.Web -c Release -o ${{env.DOTNET_ROOT}}/web
+
+      - name: Publish Admin tool
+        run: dotnet publish PeaceKeychains.Admin -c Release -o ${{env.DOTNET_ROOT}}/admin
+
+      - name: Upload Blazor artifact for deployment
         uses: actions/upload-artifact@v4
         with:
-          name: .net-app
-          path: ${{env.DOTNET_ROOT}}/myapp
+          name: blazor-app
+          path: ${{env.DOTNET_ROOT}}/blazor
+
+      - name: Upload Web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-app
+          path: ${{env.DOTNET_ROOT}}/web
+
+      - name: Upload Admin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-tool
+          path: ${{env.DOTNET_ROOT}}/admin
 
   deploy:
     permissions:
@@ -80,7 +98,7 @@ jobs:
       - name: Download artifact from build job
         uses: actions/download-artifact@v4
         with:
-          name: .net-app
+          name: blazor-app
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -59,13 +59,13 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Publish Blazor app
-        run: dotnet publish PeaceKeychains.Blazor -c Release -o ${{env.DOTNET_ROOT}}/blazor
+        run: dotnet publish PeaceKeychains.Blazor -c Release --no-build --no-restore -o ${{env.DOTNET_ROOT}}/blazor
 
       - name: Publish Web app
-        run: dotnet publish PeaceKeychains.Web -c Release -o ${{env.DOTNET_ROOT}}/web
+        run: dotnet publish PeaceKeychains.Web -c Release --no-build --no-restore -o ${{env.DOTNET_ROOT}}/web
 
       - name: Publish Admin tool
-        run: dotnet publish PeaceKeychains.Admin -c Release -o ${{env.DOTNET_ROOT}}/admin
+        run: dotnet publish PeaceKeychains.Admin -c Release --no-build --no-restore -o ${{env.DOTNET_ROOT}}/admin
 
       - name: Upload Blazor artifact for deployment
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes the multi-project solution warning by publishing each project individually:

- **`blazor-app`** — deployed to Azure App Service (unchanged behavior)
- **`web-app`** — available as downloadable artifact
- **`admin-tool`** — available as downloadable artifact (PublishSingleFile)

The deploy job now downloads only the `blazor-app` artifact for deployment.